### PR TITLE
Fixes bug which was preventing a pane name specified in the options to be set.

### DIFF
--- a/src/CanvasLayer.js
+++ b/src/CanvasLayer.js
@@ -257,7 +257,7 @@ CanvasLayer.prototype.setOptions = function(options) {
   }
 
   if (options.paneName !== undefined) {
-    this.setPane(options.paneName);
+    this.setPaneName(options.paneName);
   }
 
   if (options.updateHandler !== undefined) {


### PR DESCRIPTION
This was due to the fact that setPane method doesn't exist. Started using setPaneName instead.
